### PR TITLE
TopicStore to accept dbname parameter in constructor

### DIFF
--- a/topicdb/core/store/topicstore.py
+++ b/topicdb/core/store/topicstore.py
@@ -29,16 +29,17 @@ from topicdb.core.store.topicstoreerror import TopicStoreError
 
 
 class TopicStore:
-    def __init__(self, username, password, host='localhost', port=5432):
+    def __init__(self, username, password, host='localhost', port=5432, dbnmae="storytech"):
         self.username = username
         self.password = password
         self.host = host
         self.port = port
+	self.dbname = dbname
 
         self.connection = None
 
     def open(self):
-        self.connection = psycopg2.connect(dbname="storytech",
+        self.connection = psycopg2.connect(dbname=self.dbname,
                                            user=self.username,
                                            password=self.password,
                                            host=self.host,

--- a/topicdb/core/store/topicstore.py
+++ b/topicdb/core/store/topicstore.py
@@ -29,7 +29,7 @@ from topicdb.core.store.topicstoreerror import TopicStoreError
 
 
 class TopicStore:
-    def __init__(self, username, password, host='localhost', port=5432, dbnmae="storytech"):
+    def __init__(self, username, password, host='localhost', port=5432, dbname="storytech"):
         self.username = username
         self.password = password
         self.host = host


### PR DESCRIPTION
TopicStore currently assumes that the database name is "storytech".

Changing this is quite straightforward, but would allow people using the topic-db pip module a great deal more freedom. For example, I find myself making a copy of topicstore.py with just such a modification (the  `dbname` parameter) so I can choose the target database that it uses. 

- Added `dbname` parameter to TopicStore constructor which is defaulted to "storytech".
- This is then used in the `open` function to set up the database connection.
- No modification necessary to `bootstrap.py` or `test_topicstore.py`.